### PR TITLE
Support Different Reed Sensor Types and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,73 @@
 # marax_timer
 
-***This repository is a rewrite of [espresso_timer](https://github.com/alexrus/espresso_timer) that has better doccumentation and is easyer to use.***
+***This repository is a rewrite of [espresso_timer](https://github.com/alexrus/espresso_timer) that has better documentation and is easier to use.***
 
-This project was designed to be used with a Lelit MaraX espresso machine, but it works (only the timer functionality) with any espresso machine that has a vibration pump.
+This project was designed to be used with a Lelit MaraX espresso machine (like the Lelit Mara PL62X), but it works (only the timer functionality) with any espresso machine that has a vibration pump.
 
-**Hardware:**
+## Hardware
+
+The following hardware is needed:
 
 - NodeMCU (ESP8266)
-- 0.96" oled display
-- reed sensor
-- wires
-- 3d printed case ([https://www.thingiverse.com/thing:2937731](https://www.thingiverse.com/thing:2937731))
+    - Tested with a NodeMCU V2 CP2102 board
+- 0.96" OLED display
+    - Tested with a 4-pin version
+- Reed sensor
+    - Normally closed and normally opened works
+- Wires
+- 3D printed case ([https://www.thingiverse.com/thing:2937731](https://www.thingiverse.com/thing:2937731))
 
-**Software:**
+### Hardware Connections
 
-In order to make NodeMCU working with Arduino IDE follow these instructions: [https://www.instructables.com/id/Quick-Start-to-Nodemcu-ESP8266-on-Arduino-IDE/](https://www.instructables.com/id/Quick-Start-to-Nodemcu-ESP8266-on-Arduino-IDE/)
-
-
-**Hardware connections:**
-
-You connect the oled display like this:
+Connect the **OLED display** like this:
 ![](https://circuits4you.com/wp-content/uploads/2019/01/NodeMCU_ESP8266_OLED_Display.png)
+Remember that different display versions have different orders of VCC, GND, and data pins.
 
-The reed switch goes to ground and D7
+The **reed switch** goes to ground and D7.
 
-The reed switch will pe glued onto the machine's vibration pump like this:
+The reed switch will be glued onto the machine's vibration pump like this:
 ![](resources/pump.jpg)
 
-If you have a Lelit MaraX machine, open the underside of the machine and you will see a 6 pin connector.
+If you have a Lelit MaraX machine, open the underside of the machine and you will see a 6-pin connector.
 
 
-Connect pin 3 of the machine (RX) to pin D6 (TX) of nodeMCU
+Connect pin 3 of the machine (RX) to pin D6 (TX) of NodeMCU
 
-Connect pin 4 of the machine (TX) to pin D5 (RX) of nodeMCU
+Connect pin 4 of the machine (TX) to pin D5 (RX) of NodeMCU
 
 In case this does not work, change the pins connection (pin 3 to D5 & pin 4 to D6)
 
 
+## Software
 
-**Operation:**
+In order to make NodeMCU work with Arduino IDE, follow these instructions: [https://www.instructables.com/id/Quick-Start-to-Nodemcu-ESP8266-on-Arduino-IDE/](https://www.instructables.com/id/Quick-Start-to-Nodemcu-ESP8266-on-Arduino-IDE/)
+
+### Operation
 
 When the pump will start, the timer on the screen will also start counting.
 
-When the pump is stopped, the time will remain printed on the screen (if more that 12 seconds have passed) until the next time the pump is activated.
+When the pump is stopped, the time will remain printed on the screen (if more than 15 seconds have passed) until the next time the pump is activated.
 
-The time is not recorded unless 12 seconds have passed because MaraX machine starts the pump by itself from time to time to fill the boiler with water.
+The time is not recorded unless 15 seconds have passed because the MaraX machine starts the pump by itself from time to time to fill the boiler with water.
 
-The display should go to sleep after 1 hour, and will wake up when the pump is started.
+The display should go to sleep after 1 hour and will wake up when the pump is started.
 
+If the timer immediately starts, even when the machine is off, a wrong reed sensor is used. To solve it, replace the reed sensor with another type (normally opened / normally closed) or change the `reedOpenSensor` to `true` in the `timer.ino` file.
 
-**UI:**
+### UI
 
 ![](resources/ui.jpg)
 
 
-This project uses the following dependencies:
+### Dependencies
 
+This project uses the following dependencies:
 * [https://github.com/adafruit/Adafruit_SSD1306](https://github.com/adafruit/Adafruit_SSD1306)
 * [https://github.com/adafruit/Adafruit_BusIO](https://github.com/adafruit/Adafruit_BusIO)
 * [https://github.com/adafruit/Adafruit-GFX-Library](https://github.com/adafruit/Adafruit-GFX-Library)
 * [https://github.com/JChristensen/Timer](https://github.com/JChristensen/Timer)
 
 
+### More information
 
-More information about the project and progress [here](https://www.home-barista.com/espresso-machines/lelit-marax-t61215-350.html#p723763)
+More information about the project and progress can be found [here](https://www.home-barista.com/espresso-machines/lelit-marax-t61215-350.html#p723763).

--- a/timer/timer.ino
+++ b/timer/timer.ino
@@ -16,7 +16,7 @@ SoftwareSerial mySerial(D5, D6);
 Timer t;
 
 // set to true/false when using another type of reed sensor
-bool reedOpenSensor = false;
+bool reedOpenSensor = true;
 bool displayOn = true;
 int timerCount = 0;
 int prevTimerCount = 0;
@@ -89,9 +89,9 @@ void getMachineInput() {
 void detectChanges() {
   digitalWrite(LED_BUILTIN, digitalRead(PUMP_PIN));
   if(reedOpenSensor) {
-    pumpInValue = !digitalRead(PUMP_PIN)
-  } else {
     pumpInValue = digitalRead(PUMP_PIN)
+  } else {
+    pumpInValue = !digitalRead(PUMP_PIN)
   }
   if (!timerStarted && !pumpInValue) {
     timerStartMillis = millis();

--- a/timer/timer.ino
+++ b/timer/timer.ino
@@ -15,6 +15,8 @@ Adafruit_SSD1306 display(128, 64, &Wire, -1);
 SoftwareSerial mySerial(D5, D6);
 Timer t;
 
+// set to true/false when using another type of reed sensor
+bool reedOpenSensor = false;
 bool displayOn = true;
 int timerCount = 0;
 int prevTimerCount = 0;
@@ -23,6 +25,7 @@ long timerStartMillis = 0;
 long timerStopMillis = 0;
 long timerDisplayOffMillis = 0;
 long serialUpdateMillis = 0;
+int pumpInValue = 0;
 
 const byte numChars = 32;
 char receivedChars[numChars];
@@ -77,7 +80,7 @@ void getMachineInput() {
 
   if (millis() - serialUpdateMillis > 5000) {
     serialUpdateMillis = millis();
-    memset(receivedChars, 0, numChars );
+    memset(receivedChars, 0, numChars);
     Serial.println("Request serial update");
     mySerial.write(0x11);
   }
@@ -85,13 +88,18 @@ void getMachineInput() {
 
 void detectChanges() {
   digitalWrite(LED_BUILTIN, digitalRead(PUMP_PIN));
-  if (!timerStarted && !digitalRead(PUMP_PIN)) {
+  if(reedOpenSensor) {
+    pumpInValue = !digitalRead(PUMP_PIN)
+  } else {
+    pumpInValue = digitalRead(PUMP_PIN)
+  }
+  if (!timerStarted && !pumpInValue) {
     timerStartMillis = millis();
     timerStarted = true;
     displayOn = true;
     Serial.println("Start pump");
   }
-  if (timerStarted && digitalRead(PUMP_PIN)) {
+  if (timerStarted && pumpInValue) {
     if (timerStopMillis == 0) {
       timerStopMillis = millis();
     }


### PR DESCRIPTION
This PR solves #10 by supporting different reed sensor types with a new `reedOpenSensor` value.

It further updates the `README` with troubleshooting information, new styling, hardware information (#7), and small spelling fixes.